### PR TITLE
Deploy aggregated cluster roles

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -62,6 +62,7 @@ local rbac = import 'rbac.jsonnet';
   [if params.allow_autoscaling then '40_updater']: updater.deployment,
 
   '50_cluster_roles': rbac.cluster_roles,
+  '50_aggregated_cluster_roles': rbac.aggregated_cluster_roles,
   '50_cluster_role_bindings': rbac.cluster_role_bindings,
 
   [if std.length(params.autoscaler) > 0 then '60_vpa_resources']: vpa_resources(),

--- a/component/rbac.jsonnet
+++ b/component/rbac.jsonnet
@@ -145,6 +145,64 @@ local cr_admission_controller = kube.ClusterRole('system:vpa-admission-controlle
 };
 
 //
+// Cluster Roles which get aggregated to the standard roles
+//
+local aggregated_view = kube.ClusterRole('syn:vertical-pod-autoscaler:view') {
+  metadata+: {
+    labels+: {
+      'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+      'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+      'rbac.authorization.k8s.io/aggregate-to-view': 'true',
+      'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+    },
+  },
+  rules: [
+    {
+      apiGroups: [ 'autoscaling.k8s.io' ],
+      resources: [ 'verticalpodautoscalers' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+  ],
+};
+
+local aggregated_edit = kube.ClusterRole('syn:vertical-pod-autoscaler:edit') {
+  metadata+: {
+    labels+: {
+      'rbac.authorization.k8s.io/aggregate-to-admin': 'true',
+      'rbac.authorization.k8s.io/aggregate-to-edit': 'true',
+    },
+  },
+  rules: [
+    {
+      apiGroups: [ 'autoscaling.k8s.io' ],
+      resources: [ 'verticalpodautoscalers' ],
+      verbs: [
+        'create',
+        'delete',
+        'deletecollection',
+        'patch',
+        'update',
+      ],
+    },
+  ],
+};
+
+local aggregated_cluster_reader = kube.ClusterRole('syn:vertical-pod-autoscaler:cluster-reader') {
+  metadata+: {
+    labels+: {
+      'rbac.authorization.k8s.io/aggregate-to-cluster-reader': 'true',
+    },
+  },
+  rules: [
+    {
+      apiGroups: [ 'autoscaling.k8s.io' ],
+      resources: [ 'verticalpodautoscalercheckpoints' ],
+      verbs: [ 'get', 'list', 'watch' ],
+    },
+  ],
+};
+
+//
 // Cluster Role Bindings
 //
 
@@ -288,6 +346,12 @@ local crb_admission_controller = kube.ClusterRoleBinding('system:vpa-admission-c
       cr_admission_controller,
     ]
   ),
+
+  aggregated_cluster_roles: [
+    aggregated_view,
+    aggregated_edit,
+    aggregated_cluster_reader,
+  ],
 
   cluster_role_bindings: [
     crb_metrics_reader,

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1,5 +1,11 @@
 = vertical-pod-autoscaler
 
-vertical-pod-autoscaler is a Commodore component to manage vertical-pod-autoscaler.
+vertical-pod-autoscaler is a Commodore component to manage the https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler[vertical-pod-autoscaler].
+
+The component deploys cluster roles `syn:vertical-pod-autoscaler:view` and `syn:vertical-pod-autoscaler:edit` which are aggregated into the default `view`, `edit`, and `admin` cluster roles.
+These roles ensures that users can view `VerticalPodAutoscaler` resources in namespaces in which they have at least `view` permissions, and can edit those resources in namespaces in which they have at least `edit` permissions.
+
+The component additionally deploys a cluster role `syn:vertical-pod-autoscaler:cluster-reader`, which is aggregated to OpenShift's `cluster-reader` cluster role.
+This role allows users who have `cluster-reader` permissions to also view `VerticalPodAutoscalerCheckpoint` resources.
 
 See the xref:references/parameters.adoc[parameters] reference for further details.

--- a/tests/golden/defaults/vertical-pod-autoscaler/vertical-pod-autoscaler/50_aggregated_cluster_roles.yaml
+++ b/tests/golden/defaults/vertical-pod-autoscaler/vertical-pod-autoscaler/50_aggregated_cluster_roles.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vertical-pod-autoscaler-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn:vertical-pod-autoscaler:view
+rules:
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vertical-pod-autoscaler-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: syn:vertical-pod-autoscaler:edit
+rules:
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vertical-pod-autoscaler-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:vertical-pod-autoscaler:cluster-reader
+rules:
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - get
+      - list
+      - watch

--- a/tests/golden/full/vertical-pod-autoscaler/vertical-pod-autoscaler/50_aggregated_cluster_roles.yaml
+++ b/tests/golden/full/vertical-pod-autoscaler/vertical-pod-autoscaler/50_aggregated_cluster_roles.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vertical-pod-autoscaler-view
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+    rbac.authorization.k8s.io/aggregate-to-view: 'true'
+  name: syn:vertical-pod-autoscaler:view
+rules:
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vertical-pod-autoscaler-edit
+    rbac.authorization.k8s.io/aggregate-to-admin: 'true'
+    rbac.authorization.k8s.io/aggregate-to-edit: 'true'
+  name: syn:vertical-pod-autoscaler:edit
+rules:
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vertical-pod-autoscaler-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:vertical-pod-autoscaler:cluster-reader
+rules:
+  - apiGroups:
+      - autoscaling.k8s.io
+    resources:
+      - verticalpodautoscalercheckpoints
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
This commit ensures the default aggregated `view`, `edit`, and `admin` roles grant appropriate permissions on `VerticalPodAutoscaler` resources.

Additionally, we add read-only permissions for `VerticalPodAutoscalerCheckpoint` to the  `cluster-reader` aggregated role (note: this role may not exist on all clusters)

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
