### PR TITLE
Include runAsUser security context for non OpenShift clusters

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -5,7 +5,7 @@ local inv = kap.inventory();
 // The hiera parameters for the component
 local params = inv.parameters.vertical_pod_autoscaler;
 
-local isOpenshift = std.startsWith(inv.parameters.facts.distribution, 'openshift');
+local isOpenshift = std.member([ 'openshift4', 'oke' ], inv.parameters.facts.distribution);
 
 local namespace = kube.Namespace(params.namespace) {
   metadata+: {

--- a/component/vpa.jsonnet
+++ b/component/vpa.jsonnet
@@ -26,18 +26,18 @@ local vpa = com.Kustomization(
   },
   {
     patches: (
-	if isOpenshift then [
-      {
-        patch: |||
-          - op: remove
-            path: "/spec/template/spec/securityContext/runAsUser"
-        |||,
-        target: {
-          kind: 'Deployment',
+      if isOpenshift then [
+        {
+          patch: |||
+            - op: remove
+              path: "/spec/template/spec/securityContext/runAsUser"
+          |||,
+          target: {
+            kind: 'Deployment',
+          },
         },
-      },
       ] else []
-      ) + (
+    ) + (
       if std.length(params.recommender_args) == 0 then [] else [
         {
           patch: |||

--- a/tests/golden/defaults/vertical-pod-autoscaler/vertical-pod-autoscaler/10_kustomize/vpa/apps_v1_deployment_vpa-recommender.yaml
+++ b/tests/golden/defaults/vertical-pod-autoscaler/vertical-pod-autoscaler/10_kustomize/vpa/apps_v1_deployment_vpa-recommender.yaml
@@ -29,4 +29,5 @@ spec:
             memory: 500Mi
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65534
       serviceAccountName: vpa-recommender

--- a/tests/golden/full/vertical-pod-autoscaler/vertical-pod-autoscaler/10_kustomize/vpa/apps_v1_deployment_vpa-admission-controller.yaml
+++ b/tests/golden/full/vertical-pod-autoscaler/vertical-pod-autoscaler/10_kustomize/vpa/apps_v1_deployment_vpa-admission-controller.yaml
@@ -46,6 +46,7 @@ spec:
           readOnly: true
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65534
       serviceAccountName: vpa-admission-controller
       volumes:
       - name: tls-certs

--- a/tests/golden/full/vertical-pod-autoscaler/vertical-pod-autoscaler/10_kustomize/vpa/apps_v1_deployment_vpa-recommender.yaml
+++ b/tests/golden/full/vertical-pod-autoscaler/vertical-pod-autoscaler/10_kustomize/vpa/apps_v1_deployment_vpa-recommender.yaml
@@ -32,4 +32,5 @@ spec:
             memory: 500Mi
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65534
       serviceAccountName: vpa-recommender

--- a/tests/golden/full/vertical-pod-autoscaler/vertical-pod-autoscaler/10_kustomize/vpa/apps_v1_deployment_vpa-updater.yaml
+++ b/tests/golden/full/vertical-pod-autoscaler/vertical-pod-autoscaler/10_kustomize/vpa/apps_v1_deployment_vpa-updater.yaml
@@ -36,4 +36,5 @@ spec:
             memory: 500Mi
       securityContext:
         runAsNonRoot: true
+        runAsUser: 65534
       serviceAccountName: vpa-updater


### PR DESCRIPTION
- check if the cluster is running on OpenShift before removing the runAsUser security context. 
- OpenShift clusters automatically create a runAsUser security context automatically is non is defined.
- Non OpenShift clusters still require this security context, otherwise they will run as root with a security context of runAsNonRoot resulting in a conflict.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
